### PR TITLE
Make report uuid configurable

### DIFF
--- a/pandas_chanking.py
+++ b/pandas_chanking.py
@@ -1,10 +1,14 @@
-import pandas as pd
 import json
+from typing import Any, Dict, List, Optional
 
-def extract_test_cases(node):
-    raw = []
+import pandas as pd
+
+
+def extract_test_cases(node: Any) -> List[Dict[str, Any]]:
+    """Recursively extract test cases from an allure report tree."""
+    raw: List[Dict[str, Any]] = []
     if isinstance(node, dict):
-        if "uid" in node:  # это тест-кейс
+        if "uid" in node:
             raw.append(node)
         for child in node.get("children", []):
             raw.extend(extract_test_cases(child))
@@ -13,42 +17,73 @@ def extract_test_cases(node):
             raw.extend(extract_test_cases(item))
     return raw
 
-# Загружаем JSON
-with open("reports/response_1750420712331.json", "r", encoding="utf-8") as f:
-    data = json.load(f)
 
-# Извлекаем все тест-кейсы
-raw = extract_test_cases(data)
+def chunk_json_to_jsonl(json_data: Any, output_path: str, report_uuid: Optional[str] = None) -> pd.DataFrame:
+    """Convert raw allure JSON report into a JSONL file with additional columns.
 
-# Преобразуем в DataFrame
-df = pd.DataFrame([{
-    "uid": t.get("uid"),
-    "name": t.get("name"),
-    "parentSuite": next((l["value"] for l in t.get("labels", []) if l["name"] == "parentSuite"), "unknown"),
-    "suite": next((l["value"] for l in t.get("labels", []) if l["name"] == "suite"), "unknown"),
-    "owner": next((l["value"] for l in t.get("labels", []) if l["name"] == "owner"), "unknown"),
-    "severity": next((l["value"] for l in t.get("labels", []) if l["name"] == "severity"), "unknown"),
-    "feature": next((l["value"] for l in t.get("labels", []) if l["name"] == "feature"), "unknown"),
-    "host": next((l["value"] for l in t.get("labels", []) if l["name"] == "host"), "unknown"),
-    "status": t.get("status"),
-    "statusMessage": t.get("statusMessage", "").strip(),
-    "statusTrace": t.get("statusTrace", "").strip()
-} for t in raw])
+    Parameters
+    ----------
+    json_data : Any
+        Structure loaded from the allure API.
+    output_path : str
+        Where to save the resulting ``.jsonl`` file.
+    report_uuid : Optional[str]
+        Identifier of the processed report. When ``None`` the value is attempted
+        to be taken from ``json_data`` (``json_data['uuid']``) otherwise the
+        literal ``"unknown"`` is used.
+    """
 
-# Добавим колонку с rag-текстом
-df["rag_text"] = df.apply(lambda row: f"""Название теста: {row['name']}
-Команда: {row['parentSuite']}
-Модуль: {row['suite']}
-Владелец: {row['owner']}
-Серьёзность: {row['severity']}
-Фича: {row['feature']}
-Хост: {row['host']}
-Статус: {row['status']}
-Сообщение: {row['statusMessage']}
-Трейс: {row['statusTrace']}""", axis=1)
+    if report_uuid is None:
+        if isinstance(json_data, dict) and "uuid" in json_data:
+            report_uuid = str(json_data["uuid"])
+        else:
+            report_uuid = "unknown"
 
-# Сохраняем в формате .jsonl
-report_uuid = df["rag_text"]
-output_path = "output_chunks.jsonl"
-df.to_json(output_path, orient="records", lines=True, force_ascii=False)
-print(f"[OK] Файл сохранён: {output_path}")
+    raw = extract_test_cases(json_data)
+
+    df = pd.DataFrame(
+        [
+            {
+                "uid": t.get("uid"),
+                "name": t.get("name"),
+                "parentSuite": next((l["value"] for l in t.get("labels", []) if l["name"] == "parentSuite"), "unknown"),
+                "suite": next((l["value"] for l in t.get("labels", []) if l["name"] == "suite"), "unknown"),
+                "owner": next((l["value"] for l in t.get("labels", []) if l["name"] == "owner"), "unknown"),
+                "severity": next((l["value"] for l in t.get("labels", []) if l["name"] == "severity"), "unknown"),
+                "feature": next((l["value"] for l in t.get("labels", []) if l["name"] == "feature"), "unknown"),
+                "host": next((l["value"] for l in t.get("labels", []) if l["name"] == "host"), "unknown"),
+                "status": t.get("status"),
+                "statusMessage": t.get("statusMessage", "").strip(),
+                "statusTrace": t.get("statusTrace", "").strip(),
+            }
+            for t in raw
+        ]
+    )
+
+    df["rag_text"] = df.apply(
+        lambda row: (
+            f"Название теста: {row['name']}\n"
+            f"Команда: {row['parentSuite']}\n"
+            f"Модуль: {row['suite']}\n"
+            f"Владелец: {row['owner']}\n"
+            f"Серьёзность: {row['severity']}\n"
+            f"Фича: {row['feature']}\n"
+            f"Хост: {row['host']}\n"
+            f"Статус: {row['status']}\n"
+            f"Сообщение: {row['statusMessage']}\n"
+            f"Трейс: {row['statusTrace']}"
+        ),
+        axis=1,
+    )
+
+    df["report_uuid"] = report_uuid
+
+    df.to_json(output_path, orient="records", lines=True, force_ascii=False)
+    return df
+
+
+if __name__ == "__main__":
+    with open("reports/response_1750420712331.json", "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    chunk_json_to_jsonl(data, "output_chunks.jsonl")


### PR DESCRIPTION
## Summary
- allow passing `report_uuid` when chunking JSON
- store the uuid as a separate column in the generated dataframe

## Testing
- `python -m py_compile pandas_chanking.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68591b2a0d9883318f2b0582f394ef5e