### PR TITLE
Handle None status fields

### DIFF
--- a/pandas_chunking.py
+++ b/pandas_chunking.py
@@ -58,8 +58,8 @@ def chunk_json_to_jsonl(data, output_path: str, report_uuid: str) -> pd.DataFram
                 "unknown",
             ),
             "status": t.get("status"),
-            "statusMessage": t.get("statusMessage", "").strip(),
-            "statusTrace": t.get("statusTrace", "").strip(),
+            "statusMessage": (t.get("statusMessage") or "").strip(),
+            "statusTrace": (t.get("statusTrace") or "").strip(),
         }
         for t in raw
     ])


### PR DESCRIPTION
## Summary
- avoid failing if `statusMessage` or `statusTrace` is `None`

## Testing
- `python -m py_compile pandas_chunking.py rag_pipeline.py main.py utils.py embeddings.py save_embeddings_to_qdrant.py`

------
https://chatgpt.com/codex/tasks/task_e_685a442909c483318c2c7e9a3ef94265