### PR TITLE
Improve team extraction logic

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,11 +4,41 @@ from rag_pipeline import run_rag_analysis
 import requests
 
 def extract_team_name(report_json):
-    for test in report_json:
-        for label in test.get("labels", []):
-            if label.get("name") == "parentSuite":
-                return label.get("value")
-    return None
+    """Return the first ``parentSuite`` label value found in the report data.
+
+    The Allure API may return either a list of test dictionaries or a nested
+    dictionary structure. This function detects the root type and walks through
+    the appropriate containers until the first ``parentSuite`` label is found.
+
+    Parameters
+    ----------
+    report_json : Any
+        Parsed JSON data returned by the Allure API.
+
+    Returns
+    -------
+    str | None
+        Value of the ``parentSuite`` label or ``None`` if it is not present.
+    """
+
+    def _search(node):
+        if isinstance(node, dict):
+            for label in node.get("labels", []):
+                if label.get("name") == "parentSuite":
+                    return label.get("value")
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    result = _search(value)
+                    if result:
+                        return result
+        elif isinstance(node, list):
+            for item in node:
+                result = _search(item)
+                if result:
+                    return result
+        return None
+
+    return _search(report_json)
 
 def chunk_and_save_json(json_data, uuid, team_name):
     os.makedirs(f"chunks/{team_name}", exist_ok=True)


### PR DESCRIPTION
## Summary
- handle nested allure report structures in `extract_team_name`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a44ee80f88331bc4d1b383f550021