### PR TITLE
Implement cleanup of old chunk files

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+import os
+import time
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import types
+
+pandas_chunking_stub = types.ModuleType("pandas_chunking")
+pandas_chunking_stub.chunk_json_to_jsonl = lambda *a, **k: None
+sys.modules.setdefault("pandas_chunking", pandas_chunking_stub)
+
+rag_pipeline_stub = types.ModuleType("rag_pipeline")
+rag_pipeline_stub.run_rag_analysis = lambda *a, **k: {}
+sys.modules.setdefault("rag_pipeline", rag_pipeline_stub)
+
+requests_stub = types.ModuleType("requests")
+sys.modules.setdefault("requests", requests_stub)
+
+import utils
+
+
+def _fake_chunk_json_to_jsonl(data, path, uuid):
+    with open(path, "w") as f:
+        f.write(uuid)
+
+
+def test_cleanup_keeps_three_most_recent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, "chunk_json_to_jsonl", _fake_chunk_json_to_jsonl)
+
+    team = "team1"
+    for i in range(5):
+        utils.chunk_and_save_json({}, f"id{i}", team)
+        time.sleep(0.01)
+
+    files = sorted(os.listdir(tmp_path / "chunks" / team))
+    assert len(files) == 3
+    assert set(files) == {"id2.jsonl", "id3.jsonl", "id4.jsonl"}
+
+
+def test_no_deletion_when_three_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, "chunk_json_to_jsonl", _fake_chunk_json_to_jsonl)
+
+    team = "team2"
+    for i in range(3):
+        utils.chunk_and_save_json({}, f"id{i}", team)
+        time.sleep(0.01)
+
+    files = sorted(os.listdir(tmp_path / "chunks" / team))
+    assert len(files) == 3
+    assert set(files) == {"id0.jsonl", "id1.jsonl", "id2.jsonl"}

--- a/utils.py
+++ b/utils.py
@@ -41,16 +41,19 @@ def extract_team_name(report_json):
     return _search(report_json)
 
 def chunk_and_save_json(json_data, uuid, team_name):
-    os.makedirs(f"chunks/{team_name}", exist_ok=True)
+    base_dir = os.path.join("chunks", team_name)
+    os.makedirs(base_dir, exist_ok=True)
 
     # Чанкуем
-    output_path = f"chunks/{team_name}/{uuid}.jsonl"
+    output_path = os.path.join(base_dir, f"{uuid}.jsonl")
     chunk_json_to_jsonl(json_data, output_path, uuid)
 
     # Удаляем старые отчёты (оставляем 3)
-    files = sorted(os.listdir(f"chunks/{team_name}"))
-    if len(files) > 3:
-        os.remove(f"chunks/{team_name}/{files[0]}")
+    files = [os.path.join(base_dir, f) for f in os.listdir(base_dir)]
+    files.sort(key=os.path.getmtime, reverse=True)
+    while len(files) > 3:
+        oldest = files.pop()  # last element is the oldest
+        os.remove(oldest)
 
 def analyze_and_post(uuid, team_name):
     result = run_rag_analysis(team_name)


### PR DESCRIPTION
## Summary
- keep only the 3 newest chunk files for a team
- add tests covering cleanup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a47c6ba4083319abd444bd1f526ff