### PR TITLE
Add network error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,10 +19,12 @@ async def analyze_report(request: Request):
 
     # 1. Получаем JSON отчёт
     url = f"{ALLURE_API}/report/{uuid}/test-cases/aggregate"
-    resp = requests.get(url)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=500, detail=f"Failed to fetch report: {resp.text}")
-    
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch report: {e}") from e
+
     report_data = resp.json()
 
     # 2. Получаем название команды


### PR DESCRIPTION
## Summary
- add timeout and error handling when downloading Allure reports
- log and raise HTTP errors when posting analysis
- support running tests without fastapi installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4a4e42fc8331af7c0fb1d9026fba