### PR TITLE
Verify response status in analyze_and_post

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import time
 import sys
 import pathlib
+import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -52,3 +53,28 @@ def test_no_deletion_when_three_files(tmp_path, monkeypatch):
     files = sorted(os.listdir(tmp_path / "chunks" / team))
     assert len(files) == 3
     assert set(files) == {"id0.jsonl", "id1.jsonl", "id2.jsonl"}
+
+
+def test_analyze_and_post_non_200(monkeypatch):
+    def fake_post(url, json, timeout):
+        class Resp:
+            status_code = 500
+            text = "err"
+
+        return Resp()
+
+    monkeypatch.setattr(utils.requests, "post", fake_post, raising=False)
+    with pytest.raises(utils.HTTPException):
+        utils.analyze_and_post("uid", "team")
+
+
+def test_analyze_and_post_success(monkeypatch):
+    def fake_post(url, json, timeout):
+        class Resp:
+            status_code = 201
+            text = "ok"
+
+        return Resp()
+
+    monkeypatch.setattr(utils.requests, "post", fake_post, raising=False)
+    utils.analyze_and_post("uid", "team")

--- a/utils.py
+++ b/utils.py
@@ -73,8 +73,13 @@ def analyze_and_post(uuid, team_name):
     url = f"http://allure-report-bcc-qa:8080/api/analysis/report/{uuid}"
     try:
         resp = requests.post(url, json=result, timeout=10)
-        resp.raise_for_status()
     except requests.RequestException as e:
         logger.error("Failed to post analysis for %s: %s", uuid, e)
         raise HTTPException(status_code=500, detail=f"Failed to post analysis: {e}") from e
+
+    # Check response status explicitly so analyze_report can handle errors
+    if not 200 <= resp.status_code < 300:
+        msg = f"Unexpected status {resp.status_code}: {resp.text}"
+        logger.error("Failed to post analysis for %s: %s", uuid, msg)
+        raise HTTPException(status_code=500, detail=msg)
 


### PR DESCRIPTION
## Summary
- raise an HTTPException when posting analysis returns a non-2xx status
- test posting analysis for both success and failure cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4bc58e688331a980504e4d9afebb