### PR TITLE
Add optional Allure authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# pandas_reports
+
+This project fetches test reports from an Allure API and runs RAG analysis on them.
+
+## Environment variables
+
+- `ALLURE_API` – base URL of the Allure API (default `http://allure-report-bcc-qa:8080/api`).
+- `ALLURE_TOKEN` – if set, a bearer token used for authentication when contacting the API.
+- `ALLURE_USER` and `ALLURE_PASS` – credentials for HTTP basic authentication. These are used only when a token is not provided.
+
+When authentication variables are provided, requests made by `main.py` and `utils.py` automatically attach the appropriate `Authorization` header or basic auth parameters.

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException, Request
 import requests
 import os
-from utils import extract_team_name, chunk_and_save_json, analyze_and_post
+from utils import extract_team_name, chunk_and_save_json, analyze_and_post, _auth_kwargs
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -19,8 +19,9 @@ async def analyze_report(request: Request):
 
     # 1. Получаем JSON отчёт
     url = f"{ALLURE_API}/report/{uuid}/test-cases/aggregate"
+    auth_kwargs = _auth_kwargs()
     try:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, timeout=10, **auth_kwargs)
         resp.raise_for_status()
     except requests.RequestException as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch report: {e}") from e

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,3 +80,24 @@ def test_analyze_and_post_success(monkeypatch):
     monkeypatch.setattr(utils, "ALLURE_API", "http://example")
     monkeypatch.setattr(utils.requests, "post", fake_post, raising=False)
     utils.analyze_and_post("uid", "team")
+
+
+def test_auth_kwargs_token(monkeypatch):
+    monkeypatch.setenv("ALLURE_TOKEN", "tok")
+    monkeypatch.delenv("ALLURE_USER", raising=False)
+    monkeypatch.delenv("ALLURE_PASS", raising=False)
+    assert utils._auth_kwargs() == {"headers": {"Authorization": "Bearer tok"}}
+
+
+def test_auth_kwargs_basic(monkeypatch):
+    monkeypatch.delenv("ALLURE_TOKEN", raising=False)
+    monkeypatch.setenv("ALLURE_USER", "u")
+    monkeypatch.setenv("ALLURE_PASS", "p")
+    assert utils._auth_kwargs() == {"auth": ("u", "p")}
+
+
+def test_auth_kwargs_none(monkeypatch):
+    monkeypatch.delenv("ALLURE_TOKEN", raising=False)
+    monkeypatch.delenv("ALLURE_USER", raising=False)
+    monkeypatch.delenv("ALLURE_PASS", raising=False)
+    assert utils._auth_kwargs() == {}


### PR DESCRIPTION
## Summary
- support ALLURE_USER/ALLURE_PASS and ALLURE_TOKEN
- document configuration environment variables
- unit tests for auth helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5741ee688331a443e284180622a7