### PR TITLE
Make Qdrant configuration environment configurable

### DIFF
--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -7,7 +7,7 @@ import os
 
 # ==== Настройки ====
 MODEL_PATH = "local_models/intfloat/multilingual-e5-small"
-QDRANT_URL = "http://localhost:6333"
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 COLLECTION_NAME = "allure_chunks"
 # URL for the Ollama API can be overridden by environment variable
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")

--- a/save_embeddings_to_qdrant.py
+++ b/save_embeddings_to_qdrant.py
@@ -1,16 +1,21 @@
+import os
 import numpy as np
 import pandas as pd
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, VectorParams, PointStruct, Filter, FieldCondition, Match
 
 # Настройки
-QDRANT_URL = QdrantClient(host="localhost", port=6333)
+QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
+QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6333"))
+qdrant_client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
 COLLECTION_NAME = "allure_chunks"
 VECTOR_SIZE = 384
 
 # Загружаем данные
-df = pd.read_json("output_chunks.jsonl", lines=True)
-embeddings = np.load("embeddings.npy")
+CHUNKS_PATH = os.getenv("CHUNKS_PATH", "output_chunks.jsonl")
+EMBEDDINGS_PATH = os.getenv("EMBEDDINGS_PATH", "embeddings.npy")
+df = pd.read_json(CHUNKS_PATH, lines=True)
+embeddings = np.load(EMBEDDINGS_PATH)
 
 # Получаем название команды и UUID отчёта из первой строки
 first_row = df.iloc[0]
@@ -18,7 +23,7 @@ team = first_row["parentSuite"]
 report_uuid = first_row["report_uuid"]
 
 # Подключаемся к Qdrant
-client = QDRANT_URL
+client = qdrant_client
 
 # Создаём коллекцию, если не существует
 if not client.collection_exists(collection_name=COLLECTION_NAME):


### PR DESCRIPTION
## Summary
- rename constant `QDRANT_URL` in `save_embeddings_to_qdrant.py`
- use environment variables for qdrant host/port and data paths
- load qdrant URL from env in `rag_pipeline.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6233ea048331b04b820f2f70800f