### PR TITLE
Fix embeddings to read chunk files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,11 @@ This project fetches test reports from an Allure API and runs RAG analysis on th
 - `ALLURE_TOKEN` – if set, a bearer token used for authentication when contacting the API.
 - `ALLURE_USER` and `ALLURE_PASS` – credentials for HTTP basic authentication. These are used only when a token is not provided.
 
+- `CHUNKS_PATH` – path to a chunk file or directory containing chunk files used
+  by `embeddings.py` and `save_embeddings_to_qdrant.py` (default `chunks`).
+- `EMBEDDINGS_PATH` – file path where embeddings are stored or loaded
+  (default `embeddings.npy`).
+- `MODEL_PATH` – location of the SentenceTransformer model used for embedding
+  generation (default `local_models/intfloat/multilingual-e5-small`).
+
 When authentication variables are provided, requests made by `main.py` and `utils.py` automatically attach the appropriate `Authorization` header or basic auth parameters.

--- a/embeddings.py
+++ b/embeddings.py
@@ -1,19 +1,47 @@
-from sentence_transformers import SentenceTransformer
+"""Generate embeddings for Allure chunk files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
 import numpy as np
 import pandas as pd
+from sentence_transformers import SentenceTransformer
 
-# Загружаем модель (если уже скачана, путь можно указать локальный)
-model = SentenceTransformer("local_models/intfloat/multilingual-e5-small")
+# Paths can be overridden via environment variables
+MODEL_PATH = os.getenv("MODEL_PATH", "local_models/intfloat/multilingual-e5-small")
+CHUNKS_PATH = os.getenv("CHUNKS_PATH", "chunks")
+EMBEDDINGS_PATH = os.getenv("EMBEDDINGS_PATH", "embeddings.npy")
 
-df = pd.read_json("output_chunks.jsonl", lines=True)
 
-# Получаем список текстов для эмбеддинга
-texts = df["rag_text"].tolist()
+def load_chunks(path: str | os.PathLike) -> pd.DataFrame:
+    """Return a DataFrame with chunk data from ``path``.
 
-# Генерируем эмбеддинги
-embeddings = model.encode(texts, batch_size=64, show_progress_bar=True, convert_to_numpy=True)
+    ``path`` may point to a single ``.jsonl`` file or a directory containing
+    multiple chunk files.
+    """
+    p = Path(path)
+    if p.is_dir():
+        files = sorted(p.glob("**/*.jsonl"))
+        if not files:
+            raise FileNotFoundError(f"No .jsonl files found in {path}")
+        dfs = [pd.read_json(f, lines=True) for f in files]
+        return pd.concat(dfs, ignore_index=True)
+    return pd.read_json(p, lines=True)
 
-# Проверка формы
-print(f"[INFO] Сгенерировано эмбеддингов: {embeddings.shape}")
 
-np.save("embeddings.npy", embeddings)
+def create_embeddings(df: pd.DataFrame, model_path: str = MODEL_PATH) -> np.ndarray:
+    """Generate embeddings for the ``rag_text`` column in ``df``."""
+    model = SentenceTransformer(model_path)
+    texts = df["rag_text"].tolist()
+    return model.encode(
+        texts, batch_size=64, show_progress_bar=True, convert_to_numpy=True
+    )
+
+
+if __name__ == "__main__":
+    df = load_chunks(CHUNKS_PATH)
+    embeddings = create_embeddings(df)
+    print(f"[INFO] Сгенерировано эмбеддингов: {embeddings.shape}")
+    np.save(EMBEDDINGS_PATH, embeddings)

--- a/save_embeddings_to_qdrant.py
+++ b/save_embeddings_to_qdrant.py
@@ -2,7 +2,16 @@ import os
 import numpy as np
 import pandas as pd
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import Distance, VectorParams, PointStruct, Filter, FieldCondition, Match
+from qdrant_client.http.models import (
+    Distance,
+    VectorParams,
+    PointStruct,
+    Filter,
+    FieldCondition,
+    Match,
+)
+
+from embeddings import load_chunks
 
 # Настройки
 QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
@@ -12,9 +21,10 @@ COLLECTION_NAME = "allure_chunks"
 VECTOR_SIZE = 384
 
 # Загружаем данные
-CHUNKS_PATH = os.getenv("CHUNKS_PATH", "output_chunks.jsonl")
+CHUNKS_PATH = os.getenv("CHUNKS_PATH", "chunks")
 EMBEDDINGS_PATH = os.getenv("EMBEDDINGS_PATH", "embeddings.npy")
-df = pd.read_json(CHUNKS_PATH, lines=True)
+
+df = load_chunks(CHUNKS_PATH)
 embeddings = np.load(EMBEDDINGS_PATH)
 
 # Получаем название команды и UUID отчёта из первой строки


### PR DESCRIPTION
## Summary
- generate embeddings from `chunks/` directory by default
- update upload script to use new chunk loader
- document new environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a51b8f128833190e7c8c20091b265