### PR TITLE
Add logging and replace prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ This project fetches test reports from an Allure API and runs RAG analysis on th
   generation (default `local_models/intfloat/multilingual-e5-small`).
 
 When authentication variables are provided, requests made by `main.py` and `utils.py` automatically attach the appropriate `Authorization` header or basic auth parameters.
+
+## Logging
+
+All entry-point scripts configure Python's logging module. By default the level
+is `INFO`. Set the `LOG_LEVEL` environment variable to control verbosity, e.g.
+
+```bash
+LOG_LEVEL=DEBUG python embeddings.py
+```

--- a/embeddings.py
+++ b/embeddings.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
+import logging
 
 import numpy as np
 import pandas as pd
 from sentence_transformers import SentenceTransformer
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 # Paths can be overridden via environment variables
 MODEL_PATH = os.getenv("MODEL_PATH", "local_models/intfloat/multilingual-e5-small")
@@ -65,10 +70,10 @@ def save_embeddings(
 if __name__ == "__main__":
     df = load_chunks(CHUNKS_PATH)
     embeddings = create_embeddings(df)
-    print(f"[INFO] Сгенерировано эмбеддингов: {embeddings.shape}")
+    logger.info("Generated embeddings: %s", embeddings.shape)
 
     first_row = df.iloc[0]
     team = first_row["parentSuite"]
     report_uuid = first_row["report_uuid"]
     path = save_embeddings(embeddings, team, report_uuid)
-    print(f"[INFO] Embeddings saved to {path}")
+    logger.info("Embeddings saved to %s", path)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
 from fastapi import FastAPI, HTTPException, Request
 import requests
 import os
+import logging
 from utils import extract_team_name, chunk_and_save_json, analyze_and_post, _auth_kwargs
 from dotenv import load_dotenv
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -16,6 +21,7 @@ async def analyze_report(request: Request):
     uuid = body.get("uuid")
     if not uuid:
         raise HTTPException(status_code=400, detail="UUID not provided.")
+    logger.info("Analyze request received for UUID %s", uuid)
 
     # 1. Получаем JSON отчёт
     url = f"{ALLURE_API}/report/{uuid}/test-cases/aggregate"
@@ -23,7 +29,9 @@ async def analyze_report(request: Request):
     try:
         resp = requests.get(url, timeout=10, **auth_kwargs)
         resp.raise_for_status()
+        logger.info("Fetched report data from Allure")
     except requests.RequestException as e:
+        logger.error("Failed to fetch report for %s: %s", uuid, e)
         raise HTTPException(status_code=500, detail=f"Failed to fetch report: {e}") from e
 
     report_data = resp.json()
@@ -31,15 +39,20 @@ async def analyze_report(request: Request):
     # 2. Получаем название команды
     team_name = extract_team_name(report_data)
     if not team_name:
+        logger.error("Team name not found in report %s", uuid)
         raise HTTPException(status_code=400, detail="Team name (parentSuite) not found.")
+    logger.info("Team name extracted: %s", team_name)
 
     # 3. Чанкуем и сохраняем
     chunk_and_save_json(report_data, uuid, team_name)
+    logger.info("Chunks saved for %s", uuid)
 
     # 4. Анализ и отправка результата
     try:
         analyze_and_post(uuid, team_name)
+        logger.info("Analysis posted for %s", uuid)
     except Exception as e:
+        logger.error("Analysis failed for %s: %s", uuid, e)
         return {"result": "partial", "error": str(e)}
 
     return {"result": "ok", "team": team_name}

--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -4,6 +4,11 @@ from qdrant_client import QdrantClient
 from qdrant_client.http.models import Filter, FieldCondition, Match
 import json
 import os
+import logging
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger(__name__)
 
 # ==== Настройки ====
 MODEL_PATH = "local_models/intfloat/multilingual-e5-small"
@@ -94,10 +99,10 @@ def run_rag_analysis(team_name: str) -> dict:
 
 # ==== Основная функция ====
 def ask(question: str):
-    print(f"[Q] {question}")
+    logger.info("[Q] %s", question)
     chunks = search_similar_chunks(question, top_k=5)
     answer = generate_answer_with_ollama(chunks, question)
-    print(f"\n[A] {answer}")
+    logger.info("[A] %s", answer)
 
 
 # ==== Пример запуска ====


### PR DESCRIPTION
## Summary
- configure default logging in all entry points
- replace print calls with logger.info
- log important steps in API handler
- document LOG_LEVEL variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6a9c0acc8331a1dc837b1e64ca10