### PR TITLE
Fix qdrant Match usage

### DIFF
--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -1,7 +1,7 @@
 import requests
 from sentence_transformers import SentenceTransformer
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import Filter, FieldCondition, Match
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
 import json
 import os
 import logging
@@ -93,7 +93,7 @@ def run_rag_analysis(team_name: str) -> dict:
     """Generate a short analysis for a team's latest report using RAG."""
     client = get_client()
     search_filter = Filter(
-        must=[FieldCondition(key="team", match=Match(value=team_name))]
+        must=[FieldCondition(key="team", match=MatchValue(value=team_name))]
     )
     points, _ = client.scroll(
         collection_name=COLLECTION_NAME,

--- a/save_embeddings_to_qdrant.py
+++ b/save_embeddings_to_qdrant.py
@@ -9,7 +9,7 @@ from qdrant_client.http.models import (
     PointStruct,
     Filter,
     FieldCondition,
-    Match,
+    MatchValue,
 )
 
 from embeddings import load_chunks
@@ -51,7 +51,7 @@ if not client.collection_exists(collection_name=COLLECTION_NAME):
 
 # Удалим самые старые отчёты, если их уже 3 для этой команды
 search_filter = Filter(
-    must=[FieldCondition(key="team", match=Match(value=team))]
+    must=[FieldCondition(key="team", match=MatchValue(value=team))]
 )
 existing = client.scroll(
     collection_name=COLLECTION_NAME,

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -43,7 +43,7 @@ sys.modules.setdefault('qdrant_client.http', types.ModuleType('qdrant_client.htt
 models_mod = types.ModuleType('qdrant_client.http.models')
 models_mod.Filter = lambda *a, **k: None
 models_mod.FieldCondition = lambda *a, **k: None
-models_mod.Match = lambda *a, **k: None
+models_mod.MatchValue = lambda *a, **k: None
 sys.modules['qdrant_client.http.models'] = models_mod
 
 # requests may not be installed during tests


### PR DESCRIPTION
## Summary
- use MatchValue when building Qdrant filters
- adjust embedding loader to use MatchValue
- update qdrant stubs in rag pipeline test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6ff7de308331abbaaf5d4a07c400