### PR TITLE
Handle errors from Ollama

### DIFF
--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -88,16 +88,21 @@ def generate_answer_with_ollama(chunks, question, ollama_url: str = OLLAMA_URL):
     context = "\n\n".join(chunks)
     prompt = f"Вот информация из отчёта:\n{context}\n\nВопрос: {question}\nОтвет:"
     
-    response = requests.post(
-        ollama_url,
-        json={
-            "model": OLLAMA_MODEL,   # или другая твоя модель
-            "prompt": prompt,
-            "stream": True
-        },
-        stream=True,
-        timeout=300
-    )
+    try:
+        response = requests.post(
+            ollama_url,
+            json={
+                "model": OLLAMA_MODEL,   # или другая твоя модель
+                "prompt": prompt,
+                "stream": True
+            },
+            stream=True,
+            timeout=300
+        )
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error("Failed to generate answer via Ollama: %s", e)
+        raise RagAnalysisError("Failed to generate answer") from e
 
     answer = ""
     for line in response.iter_lines():

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -109,3 +109,20 @@ def test_run_rag_analysis_reraises(monkeypatch):
         rp.run_rag_analysis('team')
 
 
+def test_generate_answer_http_error(monkeypatch):
+    class FakeError(Exception):
+        pass
+
+    class Resp:
+        def raise_for_status(self):
+            raise FakeError("boom")
+        def iter_lines(self):
+            return []
+
+    req_mod = types.SimpleNamespace(post=lambda *a, **k: Resp(), RequestException=FakeError)
+    monkeypatch.setattr(rp, 'requests', req_mod)
+
+    with pytest.raises(rp.RagAnalysisError):
+        rp.generate_answer_with_ollama(["c"], "q")
+
+


### PR DESCRIPTION
## Summary
- ensure Ollama HTTP errors raise `RagAnalysisError`
- add regression test for the new error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7d6b295c8331a2b3e37c4aa2ea80