### PR TITLE
Improve error reporting and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,6 @@ the running service. When Qdrant is secured with an API key, set
 Increase `QDRANT_TIMEOUT` if requests to Qdrant repeatedly time out.
 Verify that `OLLAMA_URL` points to the running Ollama API when connection
 errors occur.
+A `403` response from Qdrant usually means the API key is missing or incorrect.
 If the client reports an incompatible version error, initialize it with
 `check_compatibility=False` to bypass the check.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,7 +90,7 @@ def test_analyze_and_post_qdrant_error(monkeypatch):
     monkeypatch.setattr(utils, "run_rag_analysis", fail)
     with pytest.raises(utils.HTTPException) as exc:
         utils.analyze_and_post("uid", "team")
-    assert "Qdrant service is unreachable" in str(exc.value)
+    assert str(exc.value) == "Qdrant service is unreachable: boom"
 
 
 def test_auth_kwargs_token(monkeypatch):

--- a/utils.py
+++ b/utils.py
@@ -92,7 +92,10 @@ def analyze_and_post(uuid, team_name):
         result = run_rag_analysis(team_name)
     except RagAnalysisError as e:
         logger.error("RAG analysis failed for %s: %s", uuid, e)
-        raise HTTPException(status_code=500, detail="Qdrant service is unreachable") from e
+        raise HTTPException(
+            status_code=500,
+            detail=f"Qdrant service is unreachable: {e}"
+        ) from e
 
     # Отправка анализа
     url = f"{ALLURE_API}/analysis/report/{uuid}"


### PR DESCRIPTION
## Summary
- surface RAG analysis error details in `analyze_and_post`
- clarify README troubleshooting about 403 responses
- update tests for new error message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7e5d88a48331b946cdfccbd128be