### PR TITLE
Clarify optional Qdrant API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This project fetches test reports from an Allure API and runs RAG analysis on th
 - `MODEL_PATH` – location of the SentenceTransformer model used for embedding
   generation (default `local_models/intfloat/multilingual-e5-small`).
 - `QDRANT_URL` – base URL of the Qdrant service (default `http://localhost:6333`).
-- `QDRANT_API_KEY` – API key for connecting to Qdrant, if required.
+- `QDRANT_API_KEY` – API key for connecting to Qdrant. Leave unset when the
+  service does not require authentication so the client skips sending a header.
 - `QDRANT_TIMEOUT` – request timeout for the Qdrant client (default `10`).
 - `OLLAMA_URL` – base URL of the Ollama API (default `http://localhost:11434/api/generate`).
 
@@ -55,5 +56,7 @@ Increase `QDRANT_TIMEOUT` if requests to Qdrant repeatedly time out.
 Verify that `OLLAMA_URL` points to the running Ollama API when connection
 errors occur.
 A `403` response from Qdrant usually means the API key is missing or incorrect.
+When your Qdrant instance does not enforce API keys, ensure `QDRANT_API_KEY`
+is **unset** so the client does not attempt authenticated requests.
 If the client reports an incompatible version error, initialize it with
 `check_compatibility=False` to bypass the check.

--- a/rag_pipeline.py
+++ b/rag_pipeline.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 # ==== Настройки ====
 MODEL_PATH = "local_models/intfloat/multilingual-e5-small"
 QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
-QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
+# Treat empty strings as unset so the client won't send a header when the
+# environment variable is defined but blank
+QDRANT_API_KEY = os.getenv("QDRANT_API_KEY") or None
 QDRANT_TIMEOUT = int(os.getenv("QDRANT_TIMEOUT", "10"))
 COLLECTION_NAME = "allure_chunks"
 # URL for the Ollama API can be overridden by environment variable


### PR DESCRIPTION
## Summary
- treat empty `QDRANT_API_KEY` values as unset so no header is sent
- document leaving `QDRANT_API_KEY` unset when not using authentication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a82c5403c8331947018d67d575b88