### PR TITLE
Return DataFrame from chunk_and_save_json

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,12 +51,13 @@ async def analyze_report(request: Request):
     logger.info("Team name extracted: %s", team_name)
 
     # 3. Чанкуем и сохраняем
-    json_path = chunk_and_save_json(report_data, uuid, team_name)
+    json_path, df = chunk_and_save_json(report_data, uuid, team_name)
     logger.info("Chunks saved for %s", uuid)
 
     # 4. Генерация и загрузка эмбеддингов
     try:
-        df = load_chunks(json_path)
+        if df is None:
+            df = load_chunks(json_path)
         embeddings = create_embeddings(df)
         upload_embeddings(df, embeddings, team_name, uuid)
         logger.info("Embeddings uploaded for %s", uuid)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,7 +120,7 @@ def _setup_success(monkeypatch):
     monkeypatch.setattr(main, "ALLURE_API", "http://example")
     monkeypatch.setattr(main.requests, "get", fake_get, raising=False)
     monkeypatch.setattr(main, "extract_team_name", lambda data: "team1")
-    monkeypatch.setattr(main, "chunk_and_save_json", lambda *a, **k: "out.jsonl")
+    monkeypatch.setattr(main, "chunk_and_save_json", lambda *a, **k: ("out.jsonl", []))
     monkeypatch.setattr(main, "load_chunks", lambda p: [])
     monkeypatch.setattr(main, "create_embeddings", lambda df: [])
     monkeypatch.setattr(main, "upload_embeddings", lambda *a, **k: None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,8 +34,9 @@ def test_cleanup_keeps_three_most_recent(tmp_path, monkeypatch):
 
     team = "team1"
     for i in range(5):
-        path = utils.chunk_and_save_json({}, f"id{i}", team)
+        path, df = utils.chunk_and_save_json({}, f"id{i}", team)
         assert path.endswith(f"id{i}.jsonl")
+        assert df is None
         time.sleep(0.01)
 
     files = sorted(os.listdir(tmp_path / "chunks" / team))
@@ -49,8 +50,9 @@ def test_no_deletion_when_three_files(tmp_path, monkeypatch):
 
     team = "team2"
     for i in range(3):
-        path = utils.chunk_and_save_json({}, f"id{i}", team)
+        path, df = utils.chunk_and_save_json({}, f"id{i}", team)
         assert path.endswith(f"id{i}.jsonl")
+        assert df is None
         time.sleep(0.01)
 
     files = sorted(os.listdir(tmp_path / "chunks" / team))

--- a/utils.py
+++ b/utils.py
@@ -78,7 +78,7 @@ def chunk_and_save_json(json_data, uuid, team_name):
 
     # Чанкуем
     output_path = os.path.join(base_dir, f"{uuid}.jsonl")
-    chunk_json_to_jsonl(json_data, output_path, uuid)
+    df = chunk_json_to_jsonl(json_data, output_path, uuid)
 
     # Удаляем старые отчёты (оставляем 3)
     files = [os.path.join(base_dir, f) for f in os.listdir(base_dir)]
@@ -87,7 +87,7 @@ def chunk_and_save_json(json_data, uuid, team_name):
         oldest = files.pop()  # last element is the oldest
         os.remove(oldest)
 
-    return output_path
+    return output_path, df
 
 def analyze_and_post(uuid, team_name):
     try:


### PR DESCRIPTION
## Summary
- return the DataFrame produced by `chunk_json_to_jsonl`
- use returned DataFrame in `main.analyze_report`
- update tests for new return value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a98aff7e883319dbcb3d902ac1476